### PR TITLE
Updated the sk-val init params

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -35,7 +35,7 @@ Required arguments:
 
 -   `--endpoint/-e` - RPC endpoint of the node in the network where SKALE manager is deployed (`http` or `https`)
 -   `--contracts-url/-c` - - URL to SKALE Manager contracts ABI and addresses
--   `-w/--wallet` - Type of the wallet that will be used for signing transactions (software, sgx or hardware)
+-   `-w/--wallet` - Type of the wallet that will be used for signing transactions (software, sgx or ledger)
 
 If you want to use sgx wallet you need to initialize it first (see **SGX commands**)
 


### PR DESCRIPTION
The latest `sk-val init` doesn't have a hardware param for --wallet. It has been updated to `ledger`